### PR TITLE
Add support for decorating typehinted methods

### DIFF
--- a/multiget_cache/function_tools.py
+++ b/multiget_cache/function_tools.py
@@ -3,12 +3,12 @@ import collections
 
 
 def get_arg_count(func):
-    args, varargs, keywords, defaults = inspect.getargspec(func)
+    args, *rest = inspect.getfullargspec(func)
     return len(args)
 
 
 def convert_args_to_kwargs(func, args):
-    args_names, varargs, keywords, defaults = inspect.getargspec(func)
+    args_names, *rest = inspect.getfullargspec(func)
     return dict(zip(args_names, args))
 
 
@@ -16,7 +16,7 @@ def get_default_args(func):
     """
     returns a dictionary of arg_name:default_values for the input function
     """
-    args, varargs, keywords, defaults = inspect.getargspec(func)
+    args, _, _, defaults, *rest = inspect.getfullargspec(func)
     return dict(zip(reversed(args), reversed(defaults)))
 
 
@@ -125,5 +125,5 @@ def map_arguments_to_objects(kwargs, objects, object_key, object_tuple_key, argu
 
 
 def get_kwargs_for_function(inner_f):
-    args_names, varargs, keywords, defaults = inspect.getargspec(inner_f)
+    args_names, *rest = inspect.getfullargspec(inner_f)
     return args_names

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Flask-SQLAlchemy==2.0
 Flask==0.10.1
 nose==1.3.4
+typing==3.5.2.2

--- a/test/test_end_to_end.py
+++ b/test/test_end_to_end.py
@@ -1,4 +1,5 @@
-from nose.tools import assert_equals
+from typing import List
+from nose.tools import assert_equals, with_setup
 
 import multiget_cache
 from multiget_cache.multiget_cache_wrapper import multiget_cached
@@ -12,20 +13,35 @@ class CallCounter(object):
         self.uid = id_
 
     @classmethod
+    def reset(cls):
+        cls.fake_db = {}
+        cls.call_count = 0
+
+    @classmethod
     def create(cls, id_):
         cls.fake_db[id_] = CallCounter(id_)
         return cls.fake_db[id_]
 
     @staticmethod
     @multiget_cached(object_key='uid')
-    def get(id_):
+    def get(ids):
         CallCounter.call_count += 1
-        return [CallCounter.fake_db[one_id] for one_id in id_]
+        return [CallCounter.fake_db[one_id] for one_id in ids]
+
+    @staticmethod
+    @multiget_cached(object_key='uid')
+    def get_with_typehints(ids: List[int]) -> List['CallCounter']:
+        CallCounter.call_count += 1
+        return [CallCounter.fake_db[one_id] for one_id in ids]
 
 
-def test_multiget_simple_cache():
+def reset_all():
+    CallCounter.reset()
     multiget_cache.register_cache({})
 
+
+@with_setup(setup=reset_all)
+def test_multiget_simple_cache():
     for i in range(5):
         CallCounter.create(i)
         CallCounter.get.prime(i)
@@ -44,5 +60,29 @@ def test_multiget_simple_cache():
     assert_equals(CallCounter.call_count, 2)
 
     cache_hit = CallCounter.get(2)
+    assert_equals(cache_hit.uid, 2)
+    assert_equals(CallCounter.call_count, 2)
+
+
+@with_setup(setup=reset_all)
+def test_multiget_simple_cache_with_typehints():
+    for i in range(5):
+        CallCounter.create(i)
+        CallCounter.get_with_typehints.prime(i)
+
+    first_get = CallCounter.get_with_typehints(0)
+    assert_equals(first_get.uid, 0)
+    assert_equals(CallCounter.call_count, 1)
+
+    second_get = CallCounter.get_with_typehints(1)
+    assert_equals(second_get.uid, 1)
+    assert_equals(CallCounter.call_count, 1)
+
+    CallCounter.create(9)
+    cache_miss = CallCounter.get_with_typehints(9)
+    assert_equals(cache_miss.uid, 9)
+    assert_equals(CallCounter.call_count, 2)
+
+    cache_hit = CallCounter.get_with_typehints(2)
     assert_equals(cache_hit.uid, 2)
     assert_equals(CallCounter.call_count, 2)


### PR DESCRIPTION
Currently, when using the `multiget_cached` decorator with python 3.5 or the `typing` module on a type decorated method, an error will appear prompting the code to use `getfullargspec` instead of `getargspec`.

This PR does just that. 

Unit tests included.
