### PR TITLE
Bump version to 0.0.9.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='multiget-cache',
-      version='0.0.8',
+      version='0.0.9',
       description='Python library for turning N function calls into 1 memoized call. Especially useful for SQL optimization.',
       url='http://github.com/Patreon/multiget-cache-py',
       author='Patreon',


### PR DESCRIPTION
Bump version to pull in Liran's latest changes, in which he fixes how this library interacts with function that have argspecs that consist exclusively of fully-annotated kwargs.

```
File "/code/patreon_py/patreon/model/table/actions.py", line 49, in Actions
    def get(user_id: List[int] = None, activity_id: List[int] = None, type_: List[int] = None) -> List['Actions']:
  File "/venv/lib/python3.4/site-packages/multiget_cache/multiget_cache_wrapper.py", line 107, in create_wrapper
    join_table_name, coerce_args_to_strings=coerce_args_to_strings
  File "/venv/lib/python3.4/site-packages/multiget_cache/multiget_cache_wrapper.py", line 22, in __init__
    self.argument_key = function_tools.get_kwargs_for_function(inner_f)
  File "/venv/lib/python3.4/site-packages/multiget_cache/function_tools.py", line 128, in get_kwargs_for_function
    args_names, varargs, keywords, defaults = inspect.getargspec(inner_f)
  File "/usr/lib/python3.4/inspect.py", line 936, in getargspec
    raise ValueError("Function has keyword-only arguments or annotations"
nose.proxy.ValueError: Function has keyword-only arguments or annotations, use getfullargspec() API which can support them
```
