### PR TITLE
Condence arguments to inner_f to avoid duplicates when priming multiple times

### DIFF
--- a/multiget_cache/multiget_cache_wrapper.py
+++ b/multiget_cache/multiget_cache_wrapper.py
@@ -66,7 +66,7 @@ class MultigetCacheWrapper(BaseCacheWrapper):
         cache = get_cache()
 
         # Only call with kwargs because we converted earlier
-        objects = self.inner_f(**self.kwargs_dict)
+        objects = self.inner_f(**{key: list(set(params)) for key, params in self.kwargs_dict.items()})
         # For the objects that were returned, reorder them such that they match
         # the order they were primed in, and if nothing was returned for a set
         # of arguments, use the provided default value

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='multiget-cache',
-      version='0.0.9',
+      version='0.0.10',
       description='Python library for turning N function calls into 1 memoized call. Especially useful for SQL optimization.',
       url='http://github.com/Patreon/multiget-cache-py',
       author='Patreon',


### PR DESCRIPTION
When automatically priming, several primers do not know about each other, so some times they prime the same item.
This is okay - however it makes for a very lengthy IN clause when the inner_f calls SQL.

This change does not change the way the data is stored internally, just how the inner_f is called.